### PR TITLE
feat: redesign site as landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,16 +9,43 @@
 <body>
   <header>
     <div class="wrap nav">
-      <div>Мацэ</div>
-      <nav><a href="#portfolio">Портфолио</a></nav>
+      <div class="logo">Мацэ</div>
+      <nav>
+        <a href="#services">Услуги</a>
+        <a href="#portfolio">Портфолио</a>
+        <a href="#contacts">Контакты</a>
+      </nav>
     </div>
   </header>
-  <main class="wrap">
+  <main>
     <section class="hero">
-      <h1>Мацэ — Графический и Веб-дизайнер</h1>
-      <div class="accent"></div>
+      <div class="wrap">
+        <h1>Создаю дизайн, который работает</h1>
+        <p>Графический и веб‑дизайн, брендинг и оформление.</p>
+        <a href="#portfolio" class="btn">Смотреть работы</a>
+      </div>
     </section>
-    <section id="portfolio">
+
+    <section id="services" class="services wrap">
+      <h2>Услуги</h2>
+      <div class="grid three">
+        <div class="service-card">
+          <h3>Брендинг</h3>
+          <p>Разработка фирменного стиля и логотипа.</p>
+        </div>
+        <div class="service-card">
+          <h3>Веб‑дизайн</h3>
+          <p>Создание современных сайтов и лендингов.</p>
+        </div>
+        <div class="service-card">
+          <h3>Графика</h3>
+          <p>Иллюстрации, баннеры и промо‑материалы.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="portfolio" class="wrap">
+      <h2>Портфолио</h2>
       <div class="grid">
         <figure class="card"><img src="assets/thumb-01.jpg" alt="Работа" loading="lazy" /></figure>
         <figure class="card"><img src="assets/thumb-02.jpg" alt="Работа" loading="lazy" /></figure>
@@ -32,9 +59,11 @@
         <figure class="card"><img src="assets/thumb-10.jpg" alt="Работа" loading="lazy" /></figure>
       </div>
     </section>
-    <section id="contacts" class="contacts">
-      <a href="mailto:mace4681@gmail.com">mace4681@gmail.com</a> ·
-      <a href="https://instagram.com/immalcev" target="_blank">insta: @immalcev</a> ·
+
+    <section id="contacts" class="contacts wrap">
+      <h2>Контакты</h2>
+      <a href="mailto:mace4681@gmail.com">mace4681@gmail.com</a>
+      <a href="https://instagram.com/immalcev" target="_blank">insta: @immalcev</a>
       <a href="https://instagram.com/authent.art" target="_blank">@authent.art</a>
     </section>
   </main>

--- a/style.css
+++ b/style.css
@@ -26,6 +26,7 @@ header {
   top: 0;
   background: #fff;
   border-bottom: 1px solid #eee;
+  z-index: 10;
 }
 
 .nav {
@@ -38,8 +39,26 @@ header {
   font-size: 14px;
 }
 
+.logo {
+  font-weight: 700;
+}
+
+.nav nav a {
+  margin-left: 16px;
+  text-decoration: none;
+  color: inherit;
+}
+
 .hero {
-  padding: 10vh 0 6vh;
+  padding: 12vh 0 10vh;
+  text-align: center;
+  background: #f9f9f9;
+}
+
+.hero p {
+  font-size: 20px;
+  margin: 16px 0 32px;
+  color: #555;
 }
 
 h1 {
@@ -49,20 +68,41 @@ h1 {
   font-weight: 700;
 }
 
-.accent {
-  width: 60px;
-  height: 8px;
+h2 {
+  font-size: 32px;
+  margin: 0 0 40px;
+  text-align: center;
+}
+
+.btn {
+  display: inline-block;
   background: var(--accent);
-  margin-top: 16px;
+  color: #fff;
+  padding: 12px 24px;
+  border-radius: 4px;
+  text-decoration: none;
+  font-size: 16px;
 }
 
 section {
   padding: 7vh 0;
 }
+
 .grid {
   display: grid;
   grid-template-columns: repeat(12, 1fr);
   gap: var(--gap);
+}
+
+.grid.three {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.service-card {
+  border: 1px solid #eee;
+  border-radius: 8px;
+  padding: 24px;
+  text-align: center;
 }
 
 .card {
@@ -76,11 +116,17 @@ section {
   .card {
     grid-column: span 6;
   }
+  .grid.three {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 @media (max-width: 640px) {
   .card {
     grid-column: span 12;
+  }
+  .grid.three {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -88,6 +134,10 @@ img {
   width: 100%;
   height: auto;
   display: block;
+}
+
+.contacts {
+  text-align: center;
 }
 
 .contacts a {
@@ -99,5 +149,5 @@ footer {
   padding: 14px 0;
   color: #777;
   font-size: 14px;
+  text-align: center;
 }
-


### PR DESCRIPTION
## Summary
- convert portfolio page into a simple landing layout with hero and services
- expand CSS with button, service cards, and responsive grid styling

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689692d3cc988332a10ef263ef9fba76