### PR TITLE
Refactor hero layout with containerized name and role animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,11 @@
   </header>
   <main class="wrap">
     <section class="hero">
-      <h1><span id="name">Мацэ</span> — <span class="role-wrapper"><span id="role">Графический дизайнер</span></span></h1>
+      <h1 class="hero-title">
+        <span class="name-wrapper"><span id="name">Мацэ</span></span>
+        <span class="dash">—</span>
+        <span class="role-wrapper"><span id="role">Графический дизайнер</span></span>
+      </h1>
       <div class="accent"></div>
     </section>
     <section id="portfolio">

--- a/script.js
+++ b/script.js
@@ -19,28 +19,36 @@ document.addEventListener('DOMContentLoaded', () => {
   let nameIndex = 0;
   let roleIndex = 0;
 
-  // switch name every 8 seconds
+  // switch name every 8 seconds with fade animation
   setInterval(() => {
-    nameIndex = (nameIndex + 1) % names.length;
-    nameEl.textContent = names[nameIndex];
+    nameEl.classList.add('fade');
+    setTimeout(() => {
+      nameIndex = (nameIndex + 1) % names.length;
+      nameEl.textContent = names[nameIndex];
+      nameEl.classList.remove('fade');
+    }, 500);
   }, 8000);
 
-  // helper to trigger slide animation
-  const animateRole = () => {
-    roleEl.classList.remove('slide');
-    // Trigger reflow to restart the animation
-    void roleEl.offsetWidth;
-    roleEl.classList.add('slide');
+  // switch role every 4 seconds with slide up/out effect
+  const switchRole = () => {
+    roleEl.classList.add('slide-up-out');
+    setTimeout(() => {
+      roleIndex = (roleIndex + 1) % roles.length;
+      roleEl.textContent = roles[roleIndex];
+      roleEl.classList.remove('slide-up-out');
+      roleEl.classList.add('slide-up-in');
+    }, 250);
+    setTimeout(() => {
+      roleEl.classList.remove('slide-up-in');
+    }, 500);
   };
 
-  // switch role every 4 seconds
-  setInterval(() => {
-    roleIndex = (roleIndex + 1) % roles.length;
-    roleEl.textContent = roles[roleIndex];
-    animateRole();
-  }, 4000);
+  setInterval(switchRole, 4000);
 
-  // run animation on initial load
-  animateRole();
+  // initial animation
+  roleEl.classList.add('slide-up-in');
+  setTimeout(() => {
+    roleEl.classList.remove('slide-up-in');
+  }, 500);
 });
 

--- a/style.css
+++ b/style.css
@@ -49,6 +49,76 @@ h1 {
   font-weight: 700;
 }
 
+.hero-title {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+}
+
+.name-wrapper {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.dash {
+  grid-column: 2;
+  grid-row: 1;
+  justify-self: end;
+}
+
+.role-wrapper {
+  grid-column: 1 / span 2;
+  grid-row: 2;
+  display: block;
+  overflow: hidden;
+  line-height: 1.2em;
+  height: 1.2em;
+}
+
+#name {
+  display: block;
+  transition: opacity 0.5s;
+}
+
+.fade {
+  opacity: 0;
+}
+
+#role {
+  display: block;
+  transform: translateY(0);
+}
+
+.slide-up-in {
+  animation: role-in 0.25s forwards;
+}
+
+.slide-up-out {
+  animation: role-out 0.25s forwards;
+}
+
+@keyframes role-in {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes role-out {
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+}
+
 .accent {
   width: 60px;
   height: 8px;
@@ -101,29 +171,4 @@ footer {
   font-size: 14px;
 }
 
-/* Animation for rotating role text */
-.role-wrapper {
-  display: inline-block;
-  overflow: hidden;
-  line-height: 1.2em;
-}
-
-#role {
-  display: block;
-}
-
-.slide {
-  animation: slide-up 0.5s ease;
-}
-
-@keyframes slide-up {
-  from {
-    transform: translateY(100%);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
-}
 


### PR DESCRIPTION
## Summary
- Split hero title into three containers for name, dash, and roles to keep layout stable
- Add fade animation when switching between Dima and Mace
- Slide role titles up and out before bringing in the next role from below

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6897731bf1908332be4134077e9cbbaf