### PR TITLE
Extend name display duration and restore role slide animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,7 +2,8 @@
 
 document.addEventListener('DOMContentLoaded', () => {
   const nameEl = document.getElementById('name');
-  const roleEl = document.getElementById('role');
+  let roleEl = document.getElementById('role');
+  const roleWrapper = document.querySelector('.role-wrapper');
 
   // TextScramble class for letter shuffling effect
   class TextScramble {
@@ -61,16 +62,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const phrases = [
     'Дима Мальцев',
-    ' Маце',
-    'Мацэ',
-    'Дима Мальцев'
+    'Дима',
+    'Маце',
+    'Мацэ'
   ];
 
   const fx = new TextScramble(nameEl);
   let counter = 0;
   function next() {
     fx.setText(phrases[counter]).then(() => {
-      setTimeout(next, 800);
+      setTimeout(next, 8000);
     });
     counter = (counter + 1) % phrases.length;
   }
@@ -87,9 +88,25 @@ document.addEventListener('DOMContentLoaded', () => {
   ];
   let roleIndex = 0;
   roleEl.textContent = roles[roleIndex];
-  setInterval(() => {
-    roleIndex = (roleIndex + 1) % roles.length;
-    roleEl.textContent = roles[roleIndex];
-  }, 5000);
+
+  function changeRole() {
+    const nextIndex = (roleIndex + 1) % roles.length;
+    const next = document.createElement('span');
+    next.textContent = roles[nextIndex];
+    next.classList.add('slide-in');
+    roleWrapper.appendChild(next);
+
+    roleEl.classList.add('slide-out');
+
+    setTimeout(() => {
+      roleWrapper.removeChild(roleEl);
+      next.id = 'role';
+      roleEl = next;
+    }, 500);
+
+    roleIndex = nextIndex;
+  }
+
+  setInterval(changeRole, 5000);
 });
 

--- a/style.css
+++ b/style.css
@@ -73,10 +73,19 @@ h1 {
   overflow: hidden;
   line-height: 1.2em;
   height: 1.2em;
+  position: relative;
 }
 
 #name {
   display: block;
+}
+
+.role-wrapper span {
+  display: block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
 }
 
 #role {
@@ -137,6 +146,32 @@ footer {
 
 .dud {
   color: #aaa;
+}
+
+.slide-in {
+  animation: slide-in 0.5s forwards;
+}
+
+.slide-out {
+  animation: slide-out 0.5s forwards;
+}
+
+@keyframes slide-in {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-out {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-100%);
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- lengthen rotating name phrases and include "Дима" with 8s hold time
- restore vertical sliding animation for role titles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68978c8bcca88332a08cd1e3db1c14c4