### PR TITLE
Simplify name animation and reveal header on scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,18 +8,13 @@
 </head>
 <body>
   <header>
-    <div class="wrap nav">
-      <div>Мацэ</div>
-      <nav><a href="#portfolio">Портфолио</a></nav>
+    <div class="wrap header-content">
+      <span id="header-name">Дима Мальцев</span>
     </div>
   </header>
   <main class="wrap">
     <section class="hero">
-      <h1 class="hero-title">
-        <span class="name-wrapper"><span id="name">Дима Мальцев</span></span>
-        <span class="dash">—</span>
-        <span class="role-wrapper"><span id="role">Графический дизайнер</span></span>
-      </h1>
+      <h1 id="name">Дима Мальцев</h1>
       <div class="accent"></div>
     </section>
     <section id="portfolio">

--- a/script.js
+++ b/script.js
@@ -1,9 +1,8 @@
-// Name scramble animation and role rotation
+// Name scramble animation and header visibility
 
 document.addEventListener('DOMContentLoaded', () => {
   const nameEl = document.getElementById('name');
-  let roleEl = document.getElementById('role');
-  const roleWrapper = document.querySelector('.role-wrapper');
+  const headerNameEl = document.getElementById('header-name');
 
   // TextScramble class for letter shuffling effect
   class TextScramble {
@@ -62,51 +61,37 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const phrases = [
     'Дима Мальцев',
-    'Дима',
-    'Маце',
     'Мацэ'
   ];
 
-  const fx = new TextScramble(nameEl);
+  const fxMain = new TextScramble(nameEl);
+  const fxHeader = new TextScramble(headerNameEl);
   let counter = 0;
   function next() {
-    fx.setText(phrases[counter]).then(() => {
-      setTimeout(next, 8000);
+    const phrase = phrases[counter];
+    Promise.all([
+      fxMain.setText(phrase),
+      fxHeader.setText(phrase)
+    ]).then(() => {
+      setTimeout(next, 15000);
     });
     counter = (counter + 1) % phrases.length;
   }
   next();
 
-  // Role rotation
-  const roles = [
-    'Графический дизайнер',
-    'Веб-дизайнер',
-    'Иллюстратор',
-    'Дизайнер шрифтов',
-    'Дизайнер айдентики',
-    'Дизайнер постеров'
-  ];
-  let roleIndex = 0;
-  roleEl.textContent = roles[roleIndex];
+  const header = document.querySelector('header');
+  const hero = document.querySelector('.hero');
 
-  function changeRole() {
-    const nextIndex = (roleIndex + 1) % roles.length;
-    const next = document.createElement('span');
-    next.textContent = roles[nextIndex];
-    next.classList.add('slide-in');
-    roleWrapper.appendChild(next);
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        header.classList.remove('visible');
+      } else {
+        header.classList.add('visible');
+      }
+    });
+  });
 
-    roleEl.classList.add('slide-out');
-
-    setTimeout(() => {
-      roleWrapper.removeChild(roleEl);
-      next.id = 'role';
-      roleEl = next;
-    }, 500);
-
-    roleIndex = nextIndex;
-  }
-
-  setInterval(changeRole, 5000);
+  observer.observe(hero);
 });
 

--- a/style.css
+++ b/style.css
@@ -22,20 +22,28 @@ body {
 }
 
 header {
-  position: sticky;
+  position: fixed;
   top: 0;
+  left: 0;
+  right: 0;
   background: #fff;
   border-bottom: 1px solid #eee;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s;
+  z-index: 1000;
 }
 
-.nav {
+header.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.header-content {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   padding: 12px 0;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  font-size: 14px;
 }
 
 .hero {
@@ -49,47 +57,10 @@ h1 {
   font-weight: 700;
 }
 
-.hero-title {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  grid-template-rows: auto auto;
-}
-
-.name-wrapper {
-  grid-column: 1;
-  grid-row: 1;
-}
-
-.dash {
-  grid-column: 2;
-  grid-row: 1;
-  justify-self: end;
-}
-
-.role-wrapper {
-  grid-column: 1 / span 2;
-  grid-row: 2;
-  display: block;
-  overflow: hidden;
-  line-height: 1.2em;
-  height: 1.2em;
-  position: relative;
-}
-
-#name {
-  display: block;
-}
-
-.role-wrapper span {
-  display: block;
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 100%;
-}
-
-#role {
-  display: block;
+#header-name {
+  font-size: clamp(32px, 6.5vw, 76px);
+  line-height: 0.96;
+  font-weight: 700;
 }
 
 .accent {
@@ -146,32 +117,6 @@ footer {
 
 .dud {
   color: #aaa;
-}
-
-.slide-in {
-  animation: slide-in 0.5s forwards;
-}
-
-.slide-out {
-  animation: slide-out 0.5s forwards;
-}
-
-@keyframes slide-in {
-  from {
-    transform: translateY(100%);
-  }
-  to {
-    transform: translateY(0);
-  }
-}
-
-@keyframes slide-out {
-  from {
-    transform: translateY(0);
-  }
-  to {
-    transform: translateY(-100%);
-  }
 }
 
 


### PR DESCRIPTION
## Summary
- Remove dash, role container, and portfolio link; hide header initially and show it after scrolling past the hero section.
- Slow the name animation to cycle only between “Дима Мальцев” and “Мацэ”, syncing the header and hero text.
- Simplify styles for new header behavior.

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_689791d4d89483329ef6e4f71cffbd89