### PR TITLE
Restore role section and lighten header text

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,11 @@
   </header>
   <main class="wrap">
     <section class="hero">
-      <h1 id="name">Дима Мальцев</h1>
+      <h1 class="hero-title">
+        <span class="name-wrapper"><span id="name">Дима Мальцев</span></span>
+        <span class="dash">—</span>
+        <span class="role-wrapper"><span id="role">Графический дизайнер</span></span>
+      </h1>
       <div class="accent"></div>
     </section>
     <section id="portfolio">

--- a/script.js
+++ b/script.js
@@ -3,6 +3,8 @@
 document.addEventListener('DOMContentLoaded', () => {
   const nameEl = document.getElementById('name');
   const headerNameEl = document.getElementById('header-name');
+  let roleEl = document.getElementById('role');
+  const roleWrapper = document.querySelector('.role-wrapper');
 
   // TextScramble class for letter shuffling effect
   class TextScramble {
@@ -78,6 +80,38 @@ document.addEventListener('DOMContentLoaded', () => {
     counter = (counter + 1) % phrases.length;
   }
   next();
+
+  // Role rotation
+  const roles = [
+    'Графический дизайнер',
+    'Веб-дизайнер',
+    'Иллюстратор',
+    'Дизайнер шрифтов',
+    'Дизайнер айдентики',
+    'Дизайнер постеров'
+  ];
+  let roleIndex = 0;
+  roleEl.textContent = roles[roleIndex];
+
+  function changeRole() {
+    const nextIndex = (roleIndex + 1) % roles.length;
+    const next = document.createElement('span');
+    next.textContent = roles[nextIndex];
+    next.classList.add('slide-in');
+    roleWrapper.appendChild(next);
+
+    roleEl.classList.add('slide-out');
+
+    setTimeout(() => {
+      roleWrapper.removeChild(roleEl);
+      next.id = 'role';
+      roleEl = next;
+    }, 500);
+
+    roleIndex = nextIndex;
+  }
+
+  setInterval(changeRole, 5000);
 
   const header = document.querySelector('header');
   const hero = document.querySelector('.hero');

--- a/style.css
+++ b/style.css
@@ -57,10 +57,54 @@ h1 {
   font-weight: 700;
 }
 
+.hero-title {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+}
+
+.name-wrapper {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.dash {
+  grid-column: 2;
+  grid-row: 1;
+  justify-self: end;
+}
+
+.role-wrapper {
+  grid-column: 1 / span 2;
+  grid-row: 2;
+  display: block;
+  overflow: hidden;
+  line-height: 1.2em;
+  height: 1.2em;
+  position: relative;
+}
+
+#name {
+  display: block;
+  font-weight: 200;
+}
+
+.role-wrapper span {
+  display: block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+}
+
+#role {
+  display: block;
+}
+
 #header-name {
   font-size: clamp(32px, 6.5vw, 76px);
   line-height: 0.96;
-  font-weight: 700;
+  font-weight: 200;
 }
 
 .accent {
@@ -117,6 +161,32 @@ footer {
 
 .dud {
   color: #aaa;
+}
+
+.slide-in {
+  animation: slide-in 0.5s forwards;
+}
+
+.slide-out {
+  animation: slide-out 0.5s forwards;
+}
+
+@keyframes slide-in {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-out {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-100%);
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- Reintroduce hero title layout with rotating role list and dash separator.
- Add slide animations and extra-light styling for header and hero names.
- Implement role rotation logic alongside existing name scramble and header visibility script.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689794db40948332ac6308fe3e55ff06