### PR TITLE
Use Montserrat and simplify hero layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Мацэ — Графический дизайнер</title>
+  <title>Мацэ Графический дизайнер</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@100;400;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
@@ -16,7 +17,6 @@
     <section class="hero">
       <h1 class="hero-title">
         <span class="name-wrapper"><span id="name">Дима Мальцев</span></span>
-        <span class="dash">—</span>
         <span class="role-wrapper"><span id="role">Графический дизайнер</span></span>
       </h1>
       <div class="accent"></div>
@@ -42,7 +42,7 @@
     </section>
   </main>
   <footer>
-    <div class="wrap">© Мацэ</div>
+    <div class="wrap">© <span id="footer-name">Мацэ</span></div>
   </footer>
   <script src="script.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -10,7 +10,7 @@
 
 body {
   margin: 0;
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-family: 'Montserrat', sans-serif;
   background: #fff;
   color: #000;
 }
@@ -58,35 +58,22 @@ h1 {
 }
 
 .hero-title {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  grid-template-rows: auto auto;
-}
-
-.name-wrapper {
-  grid-column: 1;
-  grid-row: 1;
-}
-
-.dash {
-  grid-column: 2;
-  grid-row: 1;
-  justify-self: end;
+  display: flex;
+  flex-direction: column;
 }
 
 .role-wrapper {
-  grid-column: 1 / span 2;
-  grid-row: 2;
   display: block;
   overflow: hidden;
   line-height: 1.2em;
   height: 1.2em;
   position: relative;
+  font-weight: 700;
 }
 
 #name {
   display: block;
-  font-weight: 200;
+  font-weight: 100;
 }
 
 .role-wrapper span {
@@ -104,7 +91,11 @@ h1 {
 #header-name {
   font-size: clamp(32px, 6.5vw, 76px);
   line-height: 0.96;
-  font-weight: 200;
+  font-weight: 100;
+}
+
+#footer-name {
+  font-weight: 100;
 }
 
 .accent {


### PR DESCRIPTION
## Summary
- Switch site typography to Montserrat and make main names thin
- Simplify hero title to two lines and bold the role text
- Add thin styling for footer signature

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68979b33a27c8332aad4048e77c04a71