### PR TITLE
Add Instagram-style post carousels and fix role label

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,20 +21,7 @@
       </h1>
       <div class="accent"></div>
     </section>
-    <section id="portfolio">
-      <div class="grid">
-        <figure class="card"><img src="assets/thumb-01.jpg" alt="Работа" loading="lazy" /></figure>
-        <figure class="card"><img src="assets/thumb-02.jpg" alt="Работа" loading="lazy" /></figure>
-        <figure class="card"><img src="assets/thumb-03.jpg" alt="Работа" loading="lazy" /></figure>
-        <figure class="card"><img src="assets/thumb-04.jpg" alt="Работа" loading="lazy" /></figure>
-        <figure class="card"><img src="assets/thumb-05.jpg" alt="Работа" loading="lazy" /></figure>
-        <figure class="card"><img src="assets/thumb-06.jpg" alt="Работа" loading="lazy" /></figure>
-        <figure class="card"><img src="assets/thumb-07.jpg" alt="Работа" loading="lazy" /></figure>
-        <figure class="card"><img src="assets/thumb-08.jpg" alt="Работа" loading="lazy" /></figure>
-        <figure class="card"><img src="assets/thumb-09.jpg" alt="Работа" loading="lazy" /></figure>
-        <figure class="card"><img src="assets/thumb-10.jpg" alt="Работа" loading="lazy" /></figure>
-      </div>
-    </section>
+    <section id="portfolio" class="posts"></section>
     <section id="contacts" class="contacts">
       <a href="mailto:mace4681@gmail.com">mace4681@gmail.com</a> ·
       <a href="https://instagram.com/immalcev" target="_blank">insta: @immalcev</a> ·

--- a/script.js
+++ b/script.js
@@ -127,5 +127,91 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   observer.observe(hero);
+
+  // Generate portfolio posts with image carousels
+  const assetFiles = [
+    'Айдентика-Ростов-1.jpg',
+    'Айдентика-Ростов-2.jpg',
+    'Айдентика-Ростов-3.jpg',
+    'Айдентика-Ростов-4.jpg',
+    'Айдентика-Ростов-5.jpg',
+    'Айдентика-Ростов-6.jpg',
+    'Логотип-Ростов-1.jpg',
+    'Обложка-Нотное_издание-1.png',
+    'Обложка-Нотное_издание-2.png',
+    'Обложка-Нотное_издание-3.png',
+    'Обложка-Нотное_издание-4.png',
+    'Обложка-Нотное_издание-5.png',
+    'Постер-Гувернантка-1.jpg',
+    'Постер-Гувернантка-2.jpg',
+    'Постер-Гувернантка-3.jpg',
+    'Постер-Гувернантка-4.jpg',
+    'Постер-Гувернантка-5.jpg',
+    'Постер-Движение-1.jpg',
+    'Постер-Движение-2.jpg',
+    'Постер-Движение-3.jpg',
+    'Постер-Движение-4.jpg',
+    'Постер-Движение-5.jpg',
+    'Постер-Майкл_Джексон-1.jpg',
+    'Постер-Майкл_Джексон-2.jpg',
+    'Постер-Форма-1.jpg'
+  ];
+
+  const postsMap = {};
+  assetFiles.forEach(file => {
+    const [section, postName, indexExt] = file.split('-');
+    const key = `${section}-${postName}`;
+    const index = parseInt(indexExt.split('.')[0], 10);
+    if (!postsMap[key]) {
+      postsMap[key] = {
+        title: `${section} ${postName.replace(/_/g, ' ')}`,
+        images: []
+      };
+    }
+    postsMap[key].images.push({ src: `assets/${file}`, index });
+  });
+
+  const posts = Object.values(postsMap);
+  posts.forEach(post => {
+    post.images.sort((a, b) => a.index - b.index);
+    post.images = post.images.map(i => i.src);
+  });
+
+  const portfolio = document.getElementById('portfolio');
+  posts.forEach(post => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'post';
+    const carousel = document.createElement('div');
+    carousel.className = 'carousel';
+    post.images.forEach(src => {
+      const img = document.createElement('img');
+      img.src = src;
+      img.alt = post.title;
+      carousel.appendChild(img);
+    });
+    wrapper.appendChild(carousel);
+
+    const title = document.createElement('h3');
+    title.className = 'post-title';
+    title.textContent = post.title;
+    wrapper.appendChild(title);
+
+    const desc = document.createElement('p');
+    desc.className = 'post-description';
+    wrapper.appendChild(desc);
+
+    portfolio.appendChild(wrapper);
+
+    const imgs = carousel.querySelectorAll('img');
+    let current = 0;
+    imgs[current].classList.add('active');
+    if (imgs.length > 1) {
+      setInterval(() => {
+        imgs[current].classList.remove('active');
+        current = (current + 1) % imgs.length;
+        imgs[current].classList.add('active');
+      }, 3000);
+    }
+  });
 });
 

--- a/style.css
+++ b/style.css
@@ -82,6 +82,7 @@ h1 {
   left: 0;
   top: 0;
   width: 100%;
+  white-space: nowrap;
 }
 
 #role {
@@ -178,6 +179,53 @@ footer {
   to {
     transform: translateY(-100%);
   }
+}
+
+/* Instagram-style posts */
+.posts {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap);
+}
+
+.post {
+  display: flex;
+  flex-direction: column;
+}
+
+.carousel {
+  position: relative;
+  width: 100%;
+  padding-top: 100%;
+  overflow: hidden;
+  border: 1px solid #eee;
+  border-radius: 8px;
+}
+
+.carousel img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0;
+  transition: opacity 0.5s;
+}
+
+.carousel img.active {
+  opacity: 1;
+}
+
+.post-title {
+  margin: 8px 0 4px;
+  font-size: 18px;
+}
+
+.post-description {
+  margin: 0;
+  font-size: 14px;
+  color: #555;
 }
 
 


### PR DESCRIPTION
## Summary
- ensure "Графический дизайнер" displays fully by preventing line breaks
- replace static portfolio grid with generated Instagram-style carousels
- add JS that groups assets into looping carousels and renders titles

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6897ab4bf9e083329940d9dbe795d5ff