### PR TITLE
feat: redesign carousel and titles

### DIFF
--- a/script.js
+++ b/script.js
@@ -164,7 +164,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const index = parseInt(indexExt.split('.')[0], 10);
     if (!postsMap[key]) {
       postsMap[key] = {
-        title: `${section} ${postName.replace(/_/g, ' ')}`,
+        category: section,
+        name: postName.replace(/_/g, ' '),
         images: []
       };
     }
@@ -181,37 +182,33 @@ document.addEventListener('DOMContentLoaded', () => {
   posts.forEach(post => {
     const wrapper = document.createElement('div');
     wrapper.className = 'post';
+
+    const topTitle = document.createElement('h3');
+    topTitle.className = 'post-title';
+    topTitle.textContent = post.category;
+    wrapper.appendChild(topTitle);
+
     const carousel = document.createElement('div');
     carousel.className = 'carousel';
+    const track = document.createElement('div');
+    track.className = 'carousel-track';
     post.images.forEach(src => {
       const img = document.createElement('img');
       img.src = src;
-      img.alt = post.title;
-      carousel.appendChild(img);
+      img.alt = `${post.category} ${post.name}`;
+      track.appendChild(img);
     });
+    // Duplicate images for seamless scroll
+    track.innerHTML += track.innerHTML;
+    carousel.appendChild(track);
     wrapper.appendChild(carousel);
 
-    const title = document.createElement('h3');
-    title.className = 'post-title';
-    title.textContent = post.title;
-    wrapper.appendChild(title);
-
-    const desc = document.createElement('p');
-    desc.className = 'post-description';
-    wrapper.appendChild(desc);
+    const bottomTitle = document.createElement('p');
+    bottomTitle.className = 'post-description';
+    bottomTitle.textContent = post.name;
+    wrapper.appendChild(bottomTitle);
 
     portfolio.appendChild(wrapper);
-
-    const imgs = carousel.querySelectorAll('img');
-    let current = 0;
-    imgs[current].classList.add('active');
-    if (imgs.length > 1) {
-      setInterval(() => {
-        imgs[current].classList.remove('active');
-        current = (current + 1) % imgs.length;
-        imgs[current].classList.add('active');
-      }, 3000);
-    }
   });
 });
 

--- a/style.css
+++ b/style.css
@@ -196,36 +196,50 @@ footer {
 .carousel {
   position: relative;
   width: 100%;
-  padding-top: 100%;
+  height: 60vw;
   overflow: hidden;
   border: 1px solid #eee;
   border-radius: 8px;
 }
 
-.carousel img {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  opacity: 0;
-  transition: opacity 0.5s;
+.carousel-track {
+  display: flex;
+  gap: 0;
+  animation: scroll-left 20s linear infinite;
 }
 
-.carousel img.active {
-  opacity: 1;
+.carousel-track img {
+  height: 100%;
+  width: auto;
+  flex-shrink: 0;
+}
+
+@keyframes scroll-left {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
 }
 
 .post-title {
-  margin: 8px 0 4px;
-  font-size: 18px;
+  margin: 8px 0;
+  font-size: 24px;
 }
 
 .post-description {
-  margin: 0;
-  font-size: 14px;
+  margin: 8px 0 0;
+  font-size: 16px;
   color: #555;
+}
+
+@media (min-width: 1024px) {
+  .carousel {
+    height: calc(60vw / 2.5);
+  }
+  .post-title {
+    font-size: 32px;
+  }
+  .post-description {
+    font-size: 20px;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- Implement horizontal infinite carousel with seamless loop and no spacing
- Separate post category and name with updated typography
- Scale desktop carousel images to maintain original aspect ratio

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6897aeee00a08332a2f1a90e4f069964