### PR TITLE
Add interactive infinite carousel with responsive sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -197,26 +197,29 @@ footer {
   position: relative;
   overflow: hidden;
   width: 100vw;
+  height: 44vh;
   margin-left: calc(50% - 50vw);
   margin-right: calc(50% - 50vw);
+  cursor: grab;
+  touch-action: pan-y;
+}
+
+.carousel:active {
+  cursor: grabbing;
 }
 
 .carousel-track {
   display: flex;
   align-items: center;
   gap: 0;
-  animation: scroll-left 8s linear infinite;
+  transition: transform 0.5s ease;
 }
 
 .carousel-track img {
-  width: 100vw;
-  height: auto;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
   flex-shrink: 0;
-}
-
-@keyframes scroll-left {
-  from { transform: translateX(0); }
-  to { transform: translateX(-50%); }
 }
 
 .post-title {


### PR DESCRIPTION
## Summary
- Make carousel span viewport width and 44vh height by default
- Add JS-driven infinite carousel with auto-scrolling and manual drag controls
- Adapt carousel height on mobile for portrait images

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_b_6897b6515b68833299fef2d7a4e25a50