### PR TITLE
feat: smooth carousel and smaller hero text

### DIFF
--- a/style.css
+++ b/style.css
@@ -51,7 +51,7 @@ header.visible {
 }
 
 h1 {
-  font-size: clamp(32px, 6.5vw, 76px);
+  font-size: clamp(28px, 6vw, 72px);
   margin: 0;
   line-height: 0.96;
   font-weight: 700;
@@ -90,7 +90,7 @@ h1 {
 }
 
 #header-name {
-  font-size: clamp(32px, 6.5vw, 76px);
+  font-size: clamp(28px, 6vw, 72px);
   line-height: 0.96;
   font-weight: 100;
 }
@@ -196,27 +196,20 @@ footer {
 .carousel {
   position: relative;
   overflow: hidden;
-  width: 100vw;
+  width: 100%;
   height: 44vh;
-  margin-left: calc(50% - 50vw);
-  margin-right: calc(50% - 50vw);
-  cursor: grab;
-  touch-action: pan-y;
-}
-
-.carousel:active {
-  cursor: grabbing;
+  margin: 0 auto;
 }
 
 .carousel-track {
   display: flex;
   align-items: center;
   gap: 0;
-  transition: transform 0.5s ease;
+  will-change: transform;
 }
 
 .carousel-track img {
-  width: 100%;
+  width: auto;
   height: 100%;
   object-fit: contain;
   flex-shrink: 0;


### PR DESCRIPTION
## Summary
- add continuous animation for portfolio image carousels
- scale images to fit height without stretching to full screen
- slightly reduce hero and header text sizes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6897b99d21a48332b57bf20ced15a1bc