### PR TITLE
feat: add responsive mobile carousel

### DIFF
--- a/script.js
+++ b/script.js
@@ -133,12 +133,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const images = Array.from(track.children);
     if (images.length === 0) return;
 
-    // duplicate images for seamless looping
-    images.forEach(img => track.appendChild(img.cloneNode(true)));
+    const mobile = window.innerWidth <= 768;
 
-    // adjust height depending on image orientation and viewport
     const adjustHeight = () => {
-      const mobile = window.innerWidth <= 768;
       const portrait = images.some(img => img.naturalHeight > img.naturalWidth);
       const h = mobile && portrait ? '60vh' : '44vh';
       carousel.style.height = h;
@@ -154,6 +151,31 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     });
     window.addEventListener('resize', adjustHeight);
+
+    if (mobile) {
+      if (images.length > 1) {
+        const indicators = document.createElement('div');
+        indicators.className = 'carousel-indicators';
+        images.forEach((_, i) => {
+          const dot = document.createElement('span');
+          if (i === 0) dot.classList.add('active');
+          indicators.appendChild(dot);
+        });
+        carousel.appendChild(indicators);
+
+        const updateIndicators = () => {
+          const index = Math.round(carousel.scrollLeft / carousel.clientWidth);
+          indicators.querySelectorAll('span').forEach((dot, i) => {
+            dot.classList.toggle('active', i === index);
+          });
+        };
+        carousel.addEventListener('scroll', updateIndicators);
+      }
+      return;
+    }
+
+    // duplicate images for seamless looping on desktop
+    images.forEach(img => track.appendChild(img.cloneNode(true)));
 
     // continuous animation using requestAnimationFrame
     let pos = 0;

--- a/style.css
+++ b/style.css
@@ -1,5 +1,6 @@
 :root {
   --accent: #E20000;
+  --sky: #87CEFA;
   --gap: 24px;
   --maxw: 1000px;
 }
@@ -216,6 +217,49 @@ footer {
   height: 100%;
   object-fit: contain;
   flex-shrink: 0;
+}
+
+@media (max-width: 768px) {
+  .carousel {
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .carousel::-webkit-scrollbar {
+    display: none;
+  }
+
+  .carousel-track {
+    will-change: auto;
+  }
+
+  .carousel-track img {
+    width: 100%;
+    border: 1px solid #eee;
+    border-radius: 16px;
+    scroll-snap-align: center;
+  }
+
+  .carousel-indicators {
+    position: absolute;
+    bottom: 8px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 6px;
+  }
+
+  .carousel-indicators span {
+    width: 8px;
+    height: 8px;
+    background: #ccc;
+    border-radius: 50%;
+  }
+
+  .carousel-indicators span.active {
+    background: var(--sky);
+  }
 }
 
 .post-title {


### PR DESCRIPTION
## Summary
- enable swipeable carousel on mobile with rounded images and sky-blue indicators
- keep desktop carousel as infinite auto-scrolling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6897beac7e288332b3376ce2e63ec0e3