### PR TITLE
Improve carousel layout and indicators

### DIFF
--- a/script.js
+++ b/script.js
@@ -133,12 +133,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const images = Array.from(track.children);
     if (images.length === 0) return;
 
-    const mobile = window.innerWidth <= 768;
-
     const adjustHeight = () => {
-      const portrait = images.some(img => img.naturalHeight > img.naturalWidth);
-      const h = mobile && portrait ? '60vh' : '44vh';
-      carousel.style.height = h;
+      const mobile = window.innerWidth <= 768;
+      if (mobile) {
+        carousel.style.height = '';
+      } else {
+        const portrait = images.some(img => img.naturalHeight > img.naturalWidth);
+        const h = portrait ? '60vh' : '44vh';
+        carousel.style.height = h;
+      }
     };
 
     let loaded = 0;
@@ -152,6 +155,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     window.addEventListener('resize', adjustHeight);
 
+    const mobile = window.innerWidth <= 768;
     if (mobile) {
       if (images.length > 1) {
         const indicators = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -183,13 +183,11 @@ footer {
 }
 
 /* Instagram-style posts */
+/*. Instagram-style posts */
 .posts {
   display: flex;
   flex-direction: column;
   gap: var(--gap);
-  width: 100vw;
-  margin-left: calc(50% - 50vw);
-  margin-right: calc(50% - 50vw);
 }
 
 .post {
@@ -200,9 +198,10 @@ footer {
 .carousel {
   position: relative;
   overflow: hidden;
-  width: 100%;
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
   height: 44vh;
-  margin: 0 auto;
 }
 
 .carousel-track {
@@ -224,6 +223,7 @@ footer {
     overflow-x: auto;
     scroll-snap-type: x mandatory;
     -webkit-overflow-scrolling: touch;
+    height: auto;
   }
 
   .carousel::-webkit-scrollbar {
@@ -236,41 +236,50 @@ footer {
 
   .carousel-track img {
     width: 100%;
+    height: auto;
     border: 1px solid #eee;
     border-radius: 16px;
     scroll-snap-align: center;
   }
 
   .carousel-indicators {
-    position: absolute;
+    position: sticky;
     bottom: 8px;
-    left: 50%;
-    transform: translateX(-50%);
+    left: 0;
+    right: 0;
     display: flex;
+    justify-content: center;
     gap: 6px;
+    pointer-events: none;
   }
 
   .carousel-indicators span {
-    width: 8px;
-    height: 8px;
-    background: #ccc;
+    width: 6px;
+    height: 6px;
+    background: rgba(0, 0, 0, 0.5);
     border-radius: 50%;
   }
 
   .carousel-indicators span.active {
+    width: 8px;
+    height: 8px;
     background: var(--sky);
   }
 }
 
 .post-title {
-  margin: 8px 0;
+  margin: 8px auto;
   font-size: 24px;
+  max-width: var(--maxw);
+  padding: 0 14px;
 }
 
 .post-description {
-  margin: 8px 0 0;
+  margin: 8px auto 0;
   font-size: 16px;
   color: #555;
+  max-width: var(--maxw);
+  padding: 0 14px;
 }
 
 @media (min-width: 1024px) {


### PR DESCRIPTION
## Summary
- ensure carousel spans full viewport width while titles stay within content width
- allow mobile carousel height to match images and keep bottom indicators pinned
- style indicators with smaller dark dots and larger blue active dot

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6897c1c75a1c833295bbcb2753e97a5a