### PR TITLE
Ensure carousel images fit height and restyle post headings

### DIFF
--- a/script.js
+++ b/script.js
@@ -178,8 +178,13 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
-    // duplicate images for seamless looping on desktop
-    images.forEach(img => track.appendChild(img.cloneNode(true)));
+    // duplicate images for seamless looping on desktop and ensure clones fit the carousel height
+    images.forEach(img => {
+      const clone = img.cloneNode(true);
+      clone.style.height = '100%';
+      clone.style.width = 'auto';
+      track.appendChild(clone);
+    });
 
     // continuous animation using requestAnimationFrame
     let pos = 0;

--- a/style.css
+++ b/style.css
@@ -205,7 +205,7 @@ footer {
 
 .carousel-track {
   display: flex;
-  align-items: center;
+  align-items: stretch;
   gap: 0;
   will-change: transform;
 }
@@ -213,6 +213,7 @@ footer {
 .carousel-track img {
   width: auto;
   height: 100%;
+  max-height: 100%;
   object-fit: contain;
   flex-shrink: 0;
 }
@@ -275,6 +276,9 @@ footer {
   font-size: 24px;
   max-width: var(--maxw);
   padding: 0 14px;
+  font-weight: 100;
+  font-style: italic;
+  color: var(--accent);
 }
 
 .post-description {
@@ -283,6 +287,7 @@ footer {
   color: #555;
   max-width: var(--maxw);
   padding: 0 14px;
+  font-weight: 700;
 }
 
 @media (min-width: 1024px) {


### PR DESCRIPTION
## Summary
- Stretch desktop carousel images to container height and set explicit sizing on duplicated slides
- Render category titles in accent extralight italic and make post names bold

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/mace_website/package.json')*

------
https://chatgpt.com/codex/tasks/task_b_6897ca1a9e888332bcc7a02e67ec4756