### PR TITLE
Fix desktop carousel image sizing and bold post categories

### DIFF
--- a/script.js
+++ b/script.js
@@ -138,9 +138,9 @@ document.addEventListener('DOMContentLoaded', () => {
       if (mobile) {
         carousel.style.height = '';
       } else {
-        const portrait = images.some(img => img.naturalHeight > img.naturalWidth);
-        const h = portrait ? '60vh' : '44vh';
-        carousel.style.height = h;
+        const width = carousel.clientWidth;
+        const ratio = images[0].naturalHeight / images[0].naturalWidth;
+        carousel.style.height = `${width * ratio}px`;
       }
     };
 

--- a/style.css
+++ b/style.css
@@ -276,7 +276,7 @@ footer {
   font-size: 24px;
   max-width: var(--maxw);
   padding: 0 14px;
-  font-weight: 100;
+  font-weight: 300;
   font-style: italic;
   color: var(--accent);
 }


### PR DESCRIPTION
## Summary
- Adjust carousel height based on image aspect ratio on desktop to prevent cropping
- Increase font weight for post category titles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6897ce47a3d083328bb318e623da3738