### PR TITLE
Adjust carousel height and image fitting

### DIFF
--- a/script.js
+++ b/script.js
@@ -134,7 +134,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (images.length === 0) return;
     const mobile = window.innerWidth <= 768;
     if (!mobile) {
-      carousel.style.height = '600px';
+      carousel.style.height = '40vh';
     }
     if (mobile) {
       if (images.length > 1) {
@@ -162,7 +162,7 @@ document.addEventListener('DOMContentLoaded', () => {
     images.forEach(img => {
       const clone = img.cloneNode(true);
       clone.style.height = '100%';
-      clone.style.width = 'auto';
+      clone.style.width = '100%';
       track.appendChild(clone);
     });
 

--- a/style.css
+++ b/style.css
@@ -200,7 +200,7 @@ footer {
   width: 100vw;
   margin-left: calc(50% - 50vw);
   margin-right: calc(50% - 50vw);
-  height: 600px;
+  height: 40vh;
 }
 
 .carousel-track {
@@ -211,9 +211,8 @@ footer {
 }
 
 .carousel-track img {
-  width: auto;
+  width: 100%;
   height: 100%;
-  max-height: 100%;
   object-fit: contain;
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary
- Use viewport-based height (40vh) for desktop carousel
- Ensure carousel images use `object-fit: contain`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6897d6fed9888332b155c45fd163de3b