### PR TITLE
Scale carousel images proportionally on desktop

### DIFF
--- a/script.js
+++ b/script.js
@@ -133,9 +133,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const images = Array.from(track.children);
     if (images.length === 0) return;
     const mobile = window.innerWidth <= 768;
-    if (!mobile) {
-      carousel.style.height = '40vh';
-    }
     if (mobile) {
       if (images.length > 1) {
         const indicators = document.createElement('div');
@@ -158,11 +155,16 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
-    // duplicate images for seamless looping on desktop and ensure clones fit the carousel height
+    // desktop specific styles
+    carousel.style.height = '40vh';
+    images.forEach(img => {
+      img.style.height = '100%';
+      img.style.objectFit = 'contain';
+    });
+
+    // duplicate images for seamless looping on desktop
     images.forEach(img => {
       const clone = img.cloneNode(true);
-      clone.style.height = '100%';
-      clone.style.width = '100%';
       track.appendChild(clone);
     });
 

--- a/style.css
+++ b/style.css
@@ -200,7 +200,6 @@ footer {
   width: 100vw;
   margin-left: calc(50% - 50vw);
   margin-right: calc(50% - 50vw);
-  height: 40vh;
 }
 
 .carousel-track {
@@ -212,9 +211,18 @@ footer {
 
 .carousel-track img {
   width: 100%;
-  height: 100%;
-  object-fit: contain;
   flex-shrink: 0;
+}
+
+@media (min-width: 769px) {
+  .carousel {
+    height: 40vh;
+  }
+
+  .carousel-track img {
+    height: 100%;
+    object-fit: contain;
+  }
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- Ensure desktop carousel spans full viewport width and occupies 40% of viewport height
- Make carousel images fill carousel height and preserve aspect ratio without cropping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6897d8d223b88332afccb4fb1f22988c